### PR TITLE
fix display NaN for netDelegatedStake

### DIFF
--- a/src/app/components/modules/UserWallet.jsx
+++ b/src/app/components/modules/UserWallet.jsx
@@ -89,13 +89,13 @@ class UserWallet extends React.Component {
               };
         const balance = tokenBalances.balance;
         const stakeBalance = tokenBalances.stake;
-        const delegatedStake = tokenBalances.delegationsOut;
+        const delegatedStake = tokenBalances.delegationsOut || 0;
         const netDelegatedStake =
             parseFloat(delegatedStake) -
-            parseFloat(tokenBalances.delegationsIn);
+            parseFloat(tokenBalances.delegationsIn || 0);
         const pendingUnstakeBalance = tokenBalances.pendingUnstake;
 
-        let isMyAccount =
+        const isMyAccount =
             current_user &&
             current_user.get('username') === account.get('name');
 
@@ -144,7 +144,7 @@ class UserWallet extends React.Component {
             .filter(el => !!el)
             .reverse();
 
-        let balance_menu = [
+        const balance_menu = [
             {
                 value: tt('userwallet_jsx.transfer'),
                 link: '#',
@@ -164,7 +164,7 @@ class UserWallet extends React.Component {
                 ),
             },
         ];
-        let power_menu = [
+        const power_menu = [
             {
                 value: tt('userwallet_jsx.power_down'),
                 link: '#',


### PR DESCRIPTION
There is no value for `delegationsOut` and `delegationsIn`.
So displayed as NaN SCT.
I fixed it. 
So I am very glad.

#### Before
![](https://user-images.githubusercontent.com/3969643/59831867-9e725980-937d-11e9-8fa6-8d4eb3c4e35e.png)

---

#### After
![](https://user-images.githubusercontent.com/3969643/59831873-a205e080-937d-11e9-86f2-d813a715b46e.png)