### PR TITLE
Modify display style for Steem Engine Token

### DIFF
--- a/src/app/components/elements/FormattedAssetToken.scss
+++ b/src/app/components/elements/FormattedAssetToken.scss
@@ -1,6 +1,6 @@
 .FormattedAssetToken {
   font-weight: 400;
-  display: inline;
+  display: inline-table;
   padding: 0.1rem 0.2rem;
   margin: 0 1rem 0 0.5rem;
   border-radius: 0.3rem;


### PR DESCRIPTION
Fixed incorrectly truncated token-balance box.
style css modified .

# Before
![](https://user-images.githubusercontent.com/3969643/60497613-264a5300-9cf0-11e9-9ddd-54756bc68742.png)

# After
![](https://user-images.githubusercontent.com/3969643/60497617-28acad00-9cf0-11e9-84fd-2a49ada23700.png)
