### PR TITLE
[SPORTS] support hierarchical categories in post index page

### DIFF
--- a/src/app/client_config.js
+++ b/src/app/client_config.js
@@ -1,4 +1,4 @@
-import { List } from 'immutable';
+import { fromJSOrdered } from './utils/immutable';
 
 // sometimes it's impossible to use html tags to style coin name, hence usage of _UPPERCASE modifier
 export const APP_NAME = 'SportsTalkSocial';
@@ -12,21 +12,21 @@ export const APP_ICON = 'sports';
 export const APP_URL = 'https://www.sportstalksocial.com';
 export const APP_DOMAIN = 'www.sportstalksocial.com';
 export const SCOT_TAG = 'sportstalk';
-export const TAG_LIST = List([
-    'football',
-    'amfootball',
-    'baseball',
-    'basketball',
-    'mma',
-    'horseracing',
-    'cricket',
-    'golf',
-    'hockey',
-    'tennis',
-    'wrestling',
-    'fantasy',
-    'esports',
-]);
+export const TAG_LIST = fromJSOrdered({
+    football: ['FIFA', 'worldcup'],
+    amfootball: ['NFL', 'collegefb'],
+    baseball: [],
+    basketball: [],
+    mma: [],
+    horseracing: [],
+    cricket: [],
+    golf: [],
+    hockey: [],
+    tennis: [],
+    wrestling: [],
+    fantasy: [],
+    esports: [],
+});
 export const LIQUID_TOKEN = 'Sports';
 // sometimes it's impossible to use html tags to style coin name, hence usage of _UPPERCASE modifier
 export const LIQUID_TOKEN_UPPERCASE = 'SPORTS';

--- a/src/app/components/pages/Topics.jsx
+++ b/src/app/components/pages/Topics.jsx
@@ -5,6 +5,7 @@ import { browserHistory } from 'react-router';
 import tt from 'counterpart';
 import PropTypes from 'prop-types';
 import NativeSelect from 'app/components/elements/NativeSelect';
+import { List } from 'immutable';
 
 const Topics = ({
     order,
@@ -33,6 +34,36 @@ const Topics = ({
         return opts['default'];
     };
 
+    const buildPrefix = level => {
+        let a = '';
+        for (let i = 0; i < level; i++) {
+            a = a + '>';
+        }
+        return a;
+    };
+
+    const buildCategories = (categories, level) => {
+        const prefix = buildPrefix(level);
+        if (List.isList(categories)) {
+            return categories.map(c => prefix + c);
+        } else {
+            let c_list = List();
+            categories.mapKeys((c, v) => {
+                c_list = c_list.push(prefix + c);
+                c_list = c_list.concat(buildCategories(v, level + 1));
+            });
+            return c_list;
+        }
+    };
+
+    const parseCategory = cat => {
+        const tag = cat.replace('>', '');
+        const label = cat.replace('>', '\u00a0\u00a0\u00a0');
+        return { tag, label };
+    };
+
+    categories = buildCategories(categories, 0);
+
     if (compact) {
         const extras = username => {
             const ex = {
@@ -53,8 +84,9 @@ const Topics = ({
         const opts = extras(username).concat(
             categories
                 .map(cat => {
-                    const link = order ? `/${order}/${cat}` : `/${cat}`;
-                    return { value: link, label: cat };
+                    const { tag, label } = parseCategory(cat);
+                    const link = order ? `/${order}/${tag}` : `/${tag}`;
+                    return { value: link, label: label };
                 })
                 .toJS()
         );
@@ -68,15 +100,16 @@ const Topics = ({
         );
     } else {
         const categoriesLinks = categories.map(cat => {
-            const link = order ? `/${order}/${cat}` : `/hot/${cat}`;
+            const { tag, label } = parseCategory(cat);
+            const link = order ? `/${order}/${tag}` : `/hot/${tag}`;
             return (
-                <li className="c-sidebar__list-item" key={cat}>
+                <li className="c-sidebar__list-item" key={tag}>
                     <Link
                         to={link}
                         className="c-sidebar__link"
                         activeClassName="active"
                     >
-                        {cat}
+                        {label}
                     </Link>
                 </li>
             );

--- a/src/app/utils/immutable.js
+++ b/src/app/utils/immutable.js
@@ -1,0 +1,13 @@
+import { Seq } from 'immutable';
+
+export function fromJSOrdered(js) {
+    return typeof js !== 'object' || js === null
+        ? js
+        : Array.isArray(js)
+          ? Seq(js)
+                .map(fromJSOrdered)
+                .toList()
+          : Seq(js)
+                .map(fromJSOrdered)
+                .toOrderedMap();
+}


### PR DESCRIPTION
### Feature

This is an enhancement wanted by @patrickurlrich for sportstalk.social, to display the left sidebar's categories panel with hierarchy.

For example:

football
--worldcup
--FIFA
amfootbale
--NFL
--collegefb
basketball
baseball
...

**screenshot: desktop browser**: the left side panel

<img width="210" alt="pic" src="https://user-images.githubusercontent.com/52878987/61185301-42ec7080-a68a-11e9-9289-381d54c8987e.png">

**screenshot: mobile browser**: the dropdown list

<img width="301" alt="pic" src="https://user-images.githubusercontent.com/52878987/61185314-5697d700-a68a-11e9-8adb-0d5d6e194ee3.png">

### Code Change

1. In `client_config.js`, modify the TAG_LIST from List to OrderedMap; `fromJSOrdered` function is added to do the conversion from Object to OrderedMap
1. In `Topics.jsx`, parse the OrderedMap categories and display in a hierarchical categories format

