### PR TITLE
add dynamic topics sidebar, and sportstube link

### DIFF
--- a/src/app/assets/icons/dtube.svg
+++ b/src/app/assets/icons/dtube.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#223154;}
+	.st1{fill:#F01A30;}
+	.st2{fill:#FFFFFF;}
+	.st3{fill:#E6E6E6;}
+	.st4{fill:#333333;}
+	.st5{fill:none;stroke:#333333;stroke-width:0.5;stroke-miterlimit:10;}
+</style>
+<g>
+	<path class="st1" d="M335.7,279.4h0.9c14.1,0,25.6,11.5,25.6,25.6v0c0,14.1-11.5,25.6-25.6,25.6h-0.9c-14.1,0-25.6-11.5-25.6-25.6
+		v0C310.1,290.9,321.6,279.4,335.7,279.4z"/>
+	<path class="st0" d="M303,197.3c-4.4-12.2-10.5-22.6-18.5-31.2c-7.9-8.6-17.5-15.2-28.6-20c-11.1-4.7-23.4-7.1-36.9-7.1h-83.4
+		v195.6h80.4c12.4,0,23.5-1.5,33.4-4.5c9.8-3,18.6-7.4,26.3-13.3c10.9-8.4,19.3-19.3,25.2-32.7c5.8-13.4,8.8-28.8,8.8-46.1
+		C309.6,223.1,307.4,209.5,303,197.3z M184.7,280.8v-87.9l75.9,44L184.7,280.8z"/>
+</g>
+</svg>

--- a/src/app/client_config.js
+++ b/src/app/client_config.js
@@ -1,4 +1,4 @@
-import { List } from 'immutable';
+import { fromJSOrdered } from './utils/immutable';
 
 // sometimes it's impossible to use html tags to style coin name, hence usage of _UPPERCASE modifier
 export const APP_NAME = 'SportsTalkSocial';
@@ -12,21 +12,21 @@ export const APP_ICON = 'sports';
 export const APP_URL = 'https://www.sportstalksocial.com';
 export const APP_DOMAIN = 'www.sportstalksocial.com';
 export const SCOT_TAG = 'sportstalk';
-export const TAG_LIST = List([
-    'football',
-    'amfootball',
-    'baseball',
-    'basketball',
-    'mma',
-    'horseracing',
-    'cricket',
-    'golf',
-    'hockey',
-    'tennis',
-    'wrestling',
-    'fantasy',
-    'esports',
-]);
+export const TAG_LIST = fromJSOrdered({
+    football: ['FIFA', 'worldcup'],
+    amfootball: ['NFL', 'collegefb'],
+    baseball: [],
+    basketball: [],
+    mma: [],
+    horseracing: [],
+    cricket: [],
+    golf: [],
+    hockey: [],
+    tennis: [],
+    wrestling: [],
+    fantasy: [],
+    esports: [],
+});
 export const LIQUID_TOKEN = 'Sports';
 // sometimes it's impossible to use html tags to style coin name, hence usage of _UPPERCASE modifier
 export const LIQUID_TOKEN_UPPERCASE = 'SPORTS';

--- a/src/app/client_config.js
+++ b/src/app/client_config.js
@@ -13,7 +13,13 @@ export const APP_URL = 'https://www.sportstalksocial.com';
 export const APP_DOMAIN = 'www.sportstalksocial.com';
 export const SCOT_TAG = 'sportstalk';
 export const TAG_LIST = fromJSOrdered({
-    football: ['FIFA', 'worldcup'],
+    football: {
+        FIFA: {
+            'euro-cup': ['euro-cup-2016', 'euro-cup-2020'],
+            'american-cup': ['american-cup-2015', 'american-cup-2019'],
+        },
+        worldcup: ['worldcup-2018', 'worldcup-2022'],
+    },
     amfootball: ['NFL', 'collegefb'],
     baseball: [],
     basketball: [],

--- a/src/app/components/elements/Icon.jsx
+++ b/src/app/components/elements/Icon.jsx
@@ -55,6 +55,7 @@ export const icons = [
     'pencil2',
     'pin',
     'pin-disabled',
+    'dtube',
 ];
 const icons_map = {};
 for (const i of icons) icons_map[i] = require(`assets/icons/${i}.svg`);

--- a/src/app/components/elements/SidebarLinks.jsx
+++ b/src/app/components/elements/SidebarLinks.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import tt from 'counterpart';
+import Icon from 'app/components/elements/Icon';
 
 const SidebarLinks = ({ username }) => (
     <div className="c-sidebar__module">
@@ -25,6 +26,18 @@ const SidebarLinks = ({ username }) => (
                         href={`/@${username}/transfers`}
                     >
                         {tt('g.my_wallet')}
+                    </a>
+                </li>
+                <li className="c-sidebar__list-item">
+                    <a
+                        className="c-sidebar__link"
+                        href={'https://video.sportstalksocial.com/'}
+                        target="_blank"
+                    >
+                        <span>
+                            {tt('g.scottube')}
+                            <Icon name="dtube" size="2x" />
+                        </span>
                     </a>
                 </li>
             </ul>

--- a/src/app/components/pages/PostsIndex.jsx
+++ b/src/app/components/pages/PostsIndex.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import tt from 'counterpart';
-import { List } from 'immutable';
+import { List, OrderedMap } from 'immutable';
 import { actions as fetchDataSagaActions } from 'app/redux/FetchDataSaga';
 import constants from 'app/redux/constants';
 import shouldComponentUpdate from 'app/utils/shouldComponentUpdate';
@@ -131,28 +131,47 @@ class PostsIndex extends React.Component {
         this.setState({ showSpam: !this.state.showSpam });
     };
 
-    loadCategories = (cat, categories) => {
-        if (!cat) return categories;
+    searchCategories(cat, parent, categories) {
+        if (!cat) return { par: parent, cats: categories };
 
         // leaf nodes
         if (List.isList(categories)) {
-            if (categories.includes(cat)) return categories;
-            else return null;
+            if (categories.includes(cat))
+                return { par: parent, cats: categories };
+            else return { par: parent, cats: null };
         } else {
             for (const c of categories.keys()) {
                 const v = categories.get(c);
                 if (cat === c && v !== null && !v.isEmpty()) {
-                    return v;
+                    return { par: parent, cats: v };
                 } else {
-                    const cats = this.loadCategories(cat, v);
+                    const { par, cats } = this.searchCategories(cat, c, v);
                     if (cats !== null && !cats.isEmpty()) {
-                        return cats;
+                        return { par, cats };
                     }
                 }
             }
-            return null;
+            return { par: parent, cats: null };
         }
-    };
+    }
+
+    buildCategories(cat, parent, categories) {
+        if (!categories) return this.props.categories;
+
+        if (!cat) {
+            return categories;
+        } else {
+            let cats = OrderedMap();
+            if (categories.includes(cat)) cats = categories;
+            else cats = cats.set(cat, categories);
+            if (parent !== null) {
+                const children = cats;
+                cats = OrderedMap();
+                cats = cats.set(parent, children);
+            }
+            return cats;
+        }
+    }
 
     render() {
         let {
@@ -161,8 +180,13 @@ class PostsIndex extends React.Component {
         } = this.props.routeParams;
 
         const { discussions, pinned } = this.props;
-        const cats = this.loadCategories(category, this.props.categories);
-        const categories = cats ? cats : this.props.categories;
+        const { par, cats } = this.searchCategories(
+            category,
+            null,
+            this.props.categories
+        );
+        const categories = this.buildCategories(category, par, cats);
+        const max_levels = category ? 3 : 2;
 
         let topics_order = order;
         let posts = List();
@@ -283,6 +307,7 @@ class PostsIndex extends React.Component {
                                     current={category}
                                     categories={categories}
                                     compact={true}
+                                    levels={max_levels}
                                 />
                             </span>
                         </div>
@@ -339,6 +364,7 @@ class PostsIndex extends React.Component {
                         compact={false}
                         username={this.props.username}
                         categories={categories}
+                        levels={max_levels}
                     />
                     <small>
                         <a

--- a/src/app/components/pages/PostsIndex.jsx
+++ b/src/app/components/pages/PostsIndex.jsx
@@ -132,26 +132,30 @@ class PostsIndex extends React.Component {
     };
 
     searchCategories(cat, parent, categories) {
-        if (!cat) return { par: parent, cats: categories };
+        if (!cat) return { par: parent, cats: categories, found: false };
 
         // leaf nodes
         if (List.isList(categories)) {
             if (categories.includes(cat))
-                return { par: parent, cats: categories };
-            else return { par: parent, cats: null };
+                return { par: parent, cats: categories, found: true };
+            else return { par: parent, cats: null, found: false };
         } else {
             for (const c of categories.keys()) {
                 const v = categories.get(c);
                 if (cat === c && v !== null && !v.isEmpty()) {
-                    return { par: parent, cats: v };
+                    return { par: parent, cats: v, found: true };
                 } else {
-                    const { par, cats } = this.searchCategories(cat, c, v);
+                    const { par, cats, found } = this.searchCategories(
+                        cat,
+                        c,
+                        v
+                    );
                     if (cats !== null && !cats.isEmpty()) {
-                        return { par, cats };
+                        return { par, cats, found };
                     }
                 }
             }
-            return { par: parent, cats: null };
+            return { par: parent, cats: null, found: false };
         }
     }
 
@@ -180,13 +184,13 @@ class PostsIndex extends React.Component {
         } = this.props.routeParams;
 
         const { discussions, pinned } = this.props;
-        const { par, cats } = this.searchCategories(
+        const { par, cats, found } = this.searchCategories(
             category,
             null,
             this.props.categories
         );
         const categories = this.buildCategories(category, par, cats);
-        const max_levels = category ? 3 : 2;
+        const max_levels = category && found ? 3 : 2;
 
         let topics_order = order;
         let posts = List();

--- a/src/app/components/pages/PostsIndex.jsx
+++ b/src/app/components/pages/PostsIndex.jsx
@@ -130,13 +130,39 @@ class PostsIndex extends React.Component {
     onShowSpam = () => {
         this.setState({ showSpam: !this.state.showSpam });
     };
+
+    loadCategories = (cat, categories) => {
+        if (!cat) return categories;
+
+        // leaf nodes
+        if (List.isList(categories)) {
+            if (categories.includes(cat)) return categories;
+            else return null;
+        } else {
+            for (const c of categories.keys()) {
+                const v = categories.get(c);
+                if (cat === c && v !== null && !v.isEmpty()) {
+                    return v;
+                } else {
+                    const cats = this.loadCategories(cat, v);
+                    if (cats !== null && !cats.isEmpty()) {
+                        return cats;
+                    }
+                }
+            }
+            return null;
+        }
+    };
+
     render() {
         let {
             category,
             order = constants.DEFAULT_SORT_ORDER,
         } = this.props.routeParams;
 
-        const { categories, discussions, pinned } = this.props;
+        const { discussions, pinned } = this.props;
+        const cats = this.loadCategories(category, this.props.categories);
+        const categories = cats ? cats : this.props.categories;
 
         let topics_order = order;
         let posts = List();

--- a/src/app/components/pages/Topics.jsx
+++ b/src/app/components/pages/Topics.jsx
@@ -14,6 +14,7 @@ const Topics = ({
     className,
     username,
     categories,
+    levels,
 }) => {
     const handleChange = selectedOption => {
         browserHistory.push(selectedOption.value);
@@ -42,7 +43,7 @@ const Topics = ({
         return a;
     };
 
-    const buildCategories = (categories, level) => {
+    const buildCategories = (categories, level, max) => {
         const prefix = buildPrefix(level);
         if (List.isList(categories)) {
             return categories.map(c => prefix + c);
@@ -50,9 +51,9 @@ const Topics = ({
             let c_list = List();
             categories.mapKeys((c, v) => {
                 c_list = c_list.push(prefix + c);
-                // only display two levels
-                if (level == 0) {
-                    c_list = c_list.concat(buildCategories(v, level + 1));
+                // only display max levels
+                if (level < max - 1) {
+                    c_list = c_list.concat(buildCategories(v, level + 1, max));
                 }
             });
             return c_list;
@@ -60,12 +61,12 @@ const Topics = ({
     };
 
     const parseCategory = cat => {
-        const tag = cat.replace('>', '');
-        const label = cat.replace('>', '\u00a0\u00a0\u00a0');
+        const tag = cat.replace(/\>/g, '');
+        const label = cat.replace(/\>/g, '\u00a0\u00a0\u00a0');
         return { tag, label };
     };
 
-    categories = buildCategories(categories, 0);
+    categories = buildCategories(categories, 0, levels);
 
     if (compact) {
         const extras = username => {

--- a/src/app/components/pages/Topics.jsx
+++ b/src/app/components/pages/Topics.jsx
@@ -66,6 +66,7 @@ const Topics = ({
         return { tag, label };
     };
 
+    const max_levels = levels || 3;
     categories = buildCategories(categories, 0, levels);
 
     if (compact) {

--- a/src/app/components/pages/Topics.jsx
+++ b/src/app/components/pages/Topics.jsx
@@ -50,7 +50,10 @@ const Topics = ({
             let c_list = List();
             categories.mapKeys((c, v) => {
                 c_list = c_list.push(prefix + c);
-                c_list = c_list.concat(buildCategories(v, level + 1));
+                // only display two levels
+                if (level == 0) {
+                    c_list = c_list.concat(buildCategories(v, level + 1));
+                }
             });
             return c_list;
         }

--- a/src/app/components/pages/Topics.jsx
+++ b/src/app/components/pages/Topics.jsx
@@ -5,6 +5,7 @@ import { browserHistory } from 'react-router';
 import tt from 'counterpart';
 import PropTypes from 'prop-types';
 import NativeSelect from 'app/components/elements/NativeSelect';
+import { List } from 'immutable';
 
 const Topics = ({
     order,
@@ -33,6 +34,36 @@ const Topics = ({
         return opts['default'];
     };
 
+    const buildPrefix = level => {
+        let a = '';
+        for (let i = 0; i < level; i++) {
+            a = a + '>';
+        }
+        return a;
+    };
+
+    const buildCategories = (categories, level) => {
+        const prefix = buildPrefix(level);
+        if (List.isList(categories)) {
+            return categories.map(c => prefix + c);
+        } else {
+            let c_list = List();
+            categories.mapKeys((c, v) => {
+                c_list = c_list.push(prefix + c);
+                c_list = c_list.concat(buildCategories(v, level + 1));
+            });
+            return c_list;
+        }
+    };
+
+    const parseCategory = cat => {
+        const tag = cat.replace('>', '');
+        const label = cat.replace('>', '\u00a0\u00a0\u00a0');
+        return { tag, label };
+    };
+
+    categories = buildCategories(categories, 0);
+
     if (compact) {
         const extras = username => {
             const ex = {
@@ -53,8 +84,9 @@ const Topics = ({
         const opts = extras(username).concat(
             categories
                 .map(cat => {
-                    const link = order ? `/${order}/${cat}` : `/${cat}`;
-                    return { value: link, label: cat };
+                    const { tag, label } = parseCategory(cat);
+                    const link = order ? `/${order}/${tag}` : `/${tag}`;
+                    return { value: link, label: label };
                 })
                 .toJS()
         );
@@ -68,15 +100,16 @@ const Topics = ({
         );
     } else {
         const categoriesLinks = categories.map(cat => {
-            const link = order ? `/${order}/${cat}` : `/hot/${cat}`;
+            const { tag, label } = parseCategory(cat);
+            const link = order ? `/${order}/${tag}` : `/hot/${tag}`;
             return (
-                <li className="c-sidebar__list-item" key={cat}>
+                <li className="c-sidebar__list-item" key={tag}>
                     <Link
                         to={link}
                         className="c-sidebar__link"
                         activeClassName="active"
                     >
-                        {cat}
+                        {label}
                     </Link>
                 </li>
             );

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -98,6 +98,7 @@
         "rewards": "Rewards",
         "save": "Save",
         "saved": "Saved",
+        "scottube": "SportsTube",
         "search": "Search",
         "sell": "Sell",
         "settings": "Settings",

--- a/src/app/locales/es.json
+++ b/src/app/locales/es.json
@@ -98,6 +98,7 @@
         "rewards": "Recompensa",
         "save": "Guardar",
         "saved": "Guardado",
+        "scottube": "SportsTube",
         "search": "Buscar",
         "sell": "Vender",
         "settings": "Configuración",

--- a/src/app/locales/fr.json
+++ b/src/app/locales/fr.json
@@ -98,6 +98,7 @@
         "rewards": "Gains",
         "save": "Sauvegarder",
         "saved": "Sauvegardé",
+        "scottube": "SportsTube",
         "search": "Rechercher",
         "sell": "Vendre",
         "settings": "Configuration",

--- a/src/app/locales/it.json
+++ b/src/app/locales/it.json
@@ -98,6 +98,7 @@
         "rewards": "Ricompense",
         "save": "Salva",
         "saved": "Salvato",
+        "scottube": "SportsTube",
         "search": "Cerca",
         "sell": "Vendi",
         "settings": "Impostazioni",

--- a/src/app/locales/ja.json
+++ b/src/app/locales/ja.json
@@ -98,6 +98,7 @@
         "rewards": "報酬",
         "save": "保存",
         "saved": "保存しました",
+        "scottube": "SportsTube",
         "search": "検索",
         "sell": "売る",
         "settings": "設定",

--- a/src/app/locales/ko.json
+++ b/src/app/locales/ko.json
@@ -98,6 +98,7 @@
         "rewards": "보상",
         "save": "Save",
         "saved": "Saved",
+        "scottube": "SportsTube",
         "search": "Search",
         "sell": "판매",
         "settings": "설정",

--- a/src/app/locales/pl.json
+++ b/src/app/locales/pl.json
@@ -98,6 +98,7 @@
         "rewards": "Nagrody",
         "save": "Zapisz",
         "saved": "Zapisane",
+        "scottube": "SportsTube",
         "search": "Szukaj",
         "sell": "Sprzedaj",
         "settings": "Ustawienia",

--- a/src/app/locales/ru.json
+++ b/src/app/locales/ru.json
@@ -100,6 +100,7 @@
         "rewards": "вознаграждение",
         "save": "Сохранить",
         "saved": "Сохранено",
+        "scottube": "SportsTube",
         "search": "Поиск",
         "sell": "Продать",
         "settings": "Настройки",

--- a/src/app/locales/zh.json
+++ b/src/app/locales/zh.json
@@ -98,6 +98,7 @@
         "rewards": "奖励",
         "save": "保存",
         "saved": "已保存",
+        "scottube": "SportsTube",
         "search": "搜索",
         "sell": "卖出",
         "settings": "设置",

--- a/src/app/utils/immutable.js
+++ b/src/app/utils/immutable.js
@@ -1,0 +1,13 @@
+import { Seq } from 'immutable';
+
+export function fromJSOrdered(js) {
+    return typeof js !== 'object' || js === null
+        ? js
+        : Array.isArray(js)
+          ? Seq(js)
+                .map(fromJSOrdered)
+                .toList()
+          : Seq(js)
+                .map(fromJSOrdered)
+                .toOrderedMap();
+}


### PR DESCRIPTION
### Features

1. in left sidebar, show the children categories for the currently selected category
1. in right sidebar, add the link to SportsTube

### Screenshots

1. show children categories

e.g. in page https://sportstalk-social.herokuapp.com/trending/football, show sub-categories:

<img width="161" alt="pic" src="https://user-images.githubusercontent.com/52944141/61303074-77426700-a819-11e9-91f9-14eb2ad62dae.png">

2. add the SportsTube link

<img width="151" alt="pic" src="https://user-images.githubusercontent.com/52944141/61303187-aeb11380-a819-11e9-859c-aa84d06f283e.png">

### Code Change

**Dynamic Topics**
1. In `PostInde.jsx`, search and build the categories tree based on the current category;
1. In `Topics.jsx`, show max level of topics and fix some issues
1. In `client_config.js`, add the categories

**SportsTube Link**
1. Modify `SidebarLinks`, `Icon`, locaes 
1. Add one logo for dtube

### Test

- https://sportstalk-social.herokuapp.com/trending/football

### Future Plan

1. Add logos for topics to make the look and feel better;
1. Show posts in all descendant categories for current category.

