### PR TITLE
add token statistics info at the sidebar

### DIFF
--- a/src/app/components/elements/SidebarToken.jsx
+++ b/src/app/components/elements/SidebarToken.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import tt from 'counterpart';
+import {
+    formatDecimal,
+    parsePayoutAmount,
+} from 'app/utils/ParsersAndFormatters';
+
+const SidebarToken = ({
+    scotToken,
+    scotTokenCirculating,
+    scotTokenBurn,
+    scotTokenStaking,
+}) => {
+    if (scotTokenCirculating && typeof scotTokenCirculating === 'string') {
+        scotTokenCirculating = parsePayoutAmount(scotTokenCirculating);
+    }
+
+    if (scotTokenBurn && typeof scotTokenBurn === 'string') {
+        scotTokenBurn = parsePayoutAmount(scotTokenBurn);
+    }
+
+    if (scotTokenStaking && typeof scotTokenStaking === 'string') {
+        scotTokenStaking = parsePayoutAmount(scotTokenStaking);
+    }
+
+    const total = formatDecimal(scotTokenCirculating + scotTokenBurn);
+    const circulating = formatDecimal(scotTokenCirculating);
+    const circulatingRate = formatDecimal(
+        scotTokenCirculating / (scotTokenCirculating + scotTokenBurn) * 100
+    );
+    const burn = formatDecimal(scotTokenBurn);
+    const burnRate = formatDecimal(
+        scotTokenBurn / (scotTokenCirculating + scotTokenBurn) * 100
+    );
+    const staking = formatDecimal(scotTokenStaking);
+    const stakingRate = formatDecimal(
+        scotTokenStaking / scotTokenCirculating * 100
+    );
+
+    const styleToken = { color: 'rgb(242, 167, 26)' };
+    const styleBurn = { color: 'red' };
+
+    return (
+        <div className="c-sidebar__module">
+            <div className="c-sidebar__header" style={styleToken}>
+                <h3 className="c-sidebar__h3">{scotToken}</h3>
+            </div>
+            <div className="c-sidebar__content">
+                <ul className="c-sidebar__list">
+                    <li className="c-sidebar__list-item">
+                        {tt('g.total')} <br />
+                        {'> '}
+                        <span className="integer">{total[0]}</span>
+                        <span className="decimal">{total[1]}</span>
+                    </li>
+                    <li className="c-sidebar__list-item">
+                        {tt('g.circulating')} (
+                        <span className="integer">{circulatingRate[0]}</span>
+                        <span className="decimal">{circulatingRate[1]}</span>
+                        %) <br />
+                        {'> '}
+                        <span className="integer">{circulating[0]}</span>
+                        <span className="decimal">{circulating[1]}</span>
+                    </li>
+                    <li className="c-sidebar__list-item" style={styleBurn}>
+                        {tt('g.burn')} (
+                        <span className="integer">{burnRate[0]}</span>
+                        <span className="decimal">{burnRate[1]}</span>
+                        %) <br />
+                        {'> '}
+                        <span className="integer">{burn[0]}</span>
+                        <span className="decimal">{burn[1]}</span>
+                    </li>
+                    <li className="c-sidebar__list-item">
+                        {tt('g.staking')} (
+                        <span className="integer">{stakingRate[0]}</span>
+                        <span className="decimal">{stakingRate[1]}</span>
+                        %) <br />
+                        {'> '}
+                        <span className="integer">{staking[0]}</span>
+                        <span className="decimal">{staking[1]}</span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    );
+};
+
+export default SidebarToken;

--- a/src/app/components/elements/SidebarToken.jsx
+++ b/src/app/components/elements/SidebarToken.jsx
@@ -47,12 +47,14 @@ const SidebarToken = ({
             </div>
             <div className="c-sidebar__content">
                 <ul className="c-sidebar__list">
-                    <li className="c-sidebar__list-item">
-                        {tt('g.total')} <br />
-                        {'> '}
-                        <span className="integer">{total[0]}</span>
-                        <span className="decimal">{total[1]}</span>
-                    </li>
+                    {scotTokenBurn > 0 && (
+                        <li className="c-sidebar__list-item">
+                            {tt('g.total')} <br />
+                            {'> '}
+                            <span className="integer">{total[0]}</span>
+                            <span className="decimal">{total[1]}</span>
+                        </li>
+                    )}
                     <li className="c-sidebar__list-item">
                         {tt('g.circulating')} (
                         <span className="integer">{circulatingRate[0]}</span>

--- a/src/app/components/elements/SidebarToken.jsx
+++ b/src/app/components/elements/SidebarToken.jsx
@@ -62,15 +62,17 @@ const SidebarToken = ({
                         <span className="integer">{circulating[0]}</span>
                         <span className="decimal">{circulating[1]}</span>
                     </li>
-                    <li className="c-sidebar__list-item" style={styleBurn}>
-                        {tt('g.burn')} (
-                        <span className="integer">{burnRate[0]}</span>
-                        <span className="decimal">{burnRate[1]}</span>
-                        %) <br />
-                        {'> '}
-                        <span className="integer">{burn[0]}</span>
-                        <span className="decimal">{burn[1]}</span>
-                    </li>
+                    {scotTokenBurn > 0 && (
+                        <li className="c-sidebar__list-item" style={styleBurn}>
+                            {tt('g.burn')} (
+                            <span className="integer">{burnRate[0]}</span>
+                            <span className="decimal">{burnRate[1]}</span>
+                            %) <br />
+                            {'> '}
+                            <span className="integer">{burn[0]}</span>
+                            <span className="decimal">{burn[1]}</span>
+                        </li>
+                    )}
                     <li className="c-sidebar__list-item">
                         {tt('g.staking')} (
                         <span className="integer">{stakingRate[0]}</span>

--- a/src/app/components/pages/PostsIndex.jsx
+++ b/src/app/components/pages/PostsIndex.jsx
@@ -355,6 +355,7 @@ class PostsIndex extends React.Component {
                             <SidebarLinks username={this.props.username} />
                         </div>
                     )}
+                    <Notices notices={this.props.notices} />
                     {this.props.isBrowser && (
                         <div>
                             <SidebarToken
@@ -429,7 +430,6 @@ class PostsIndex extends React.Component {
                             />
                         </div>
                     )}
-                    <Notices notices={this.props.notices} />
                     {this.props.gptEnabled ? (
                         <div className="sidebar-ad">
                             <GptAd type="Freestar" id="steemit_160x600_Right" />

--- a/src/app/components/pages/PostsIndex.jsx
+++ b/src/app/components/pages/PostsIndex.jsx
@@ -22,6 +22,8 @@ import Topics from './Topics';
 import SortOrder from 'app/components/elements/SortOrder';
 import { PROMOTED_POST_PAD_SIZE } from 'shared/constants';
 
+import SidebarToken from 'app/components/elements/SidebarToken';
+
 class PostsIndex extends React.Component {
     static propTypes = {
         discussions: PropTypes.object,
@@ -353,6 +355,80 @@ class PostsIndex extends React.Component {
                             <SidebarLinks username={this.props.username} />
                         </div>
                     )}
+                    {this.props.isBrowser && (
+                        <div>
+                            <SidebarToken
+                                scotToken={this.props.tokenStats.getIn([
+                                    'scotToken',
+                                ])}
+                                scotTokenCirculating={this.props.tokenStats.getIn(
+                                    ['total_token_balance', 'circulatingSupply']
+                                )}
+                                scotTokenBurn={
+                                    this.props.tokenStats.getIn([
+                                        'token_burn_balance',
+                                        'balance',
+                                    ]) || 0
+                                }
+                                scotTokenStaking={this.props.tokenStats.getIn([
+                                    'total_token_balance',
+                                    'totalStaked',
+                                ])}
+                            />
+                        </div>
+                    )}
+                    {this.props.isBrowser && (
+                        <div>
+                            <SidebarToken
+                                scotToken={this.props.tokenStats.getIn([
+                                    'scotMinerTokens',
+                                    0,
+                                ])}
+                                scotTokenCirculating={this.props.tokenStats.getIn(
+                                    [
+                                        'total_token_miner_balance',
+                                        'circulatingSupply',
+                                    ]
+                                )}
+                                scotTokenBurn={
+                                    this.props.tokenStats.getIn([
+                                        'token_miner_burn_balance',
+                                        'balance',
+                                    ]) || 0
+                                }
+                                scotTokenStaking={this.props.tokenStats.getIn([
+                                    'total_token_miner_balance',
+                                    'totalStaked',
+                                ])}
+                            />
+                        </div>
+                    )}
+                    {this.props.isBrowser && (
+                        <div>
+                            <SidebarToken
+                                scotToken={this.props.tokenStats.getIn([
+                                    'scotMinerTokens',
+                                    1,
+                                ])}
+                                scotTokenCirculating={this.props.tokenStats.getIn(
+                                    [
+                                        'total_token_mega_miner_balance',
+                                        'circulatingSupply',
+                                    ]
+                                )}
+                                scotTokenBurn={
+                                    this.props.tokenStats.getIn([
+                                        'token_mega_miner_burn_balance',
+                                        'balance',
+                                    ]) || 0
+                                }
+                                scotTokenStaking={this.props.tokenStats.getIn([
+                                    'total_token_mega_miner_balance',
+                                    'totalStaked',
+                                ])}
+                            />
+                        </div>
+                    )}
                     <Notices notices={this.props.notices} />
                     {this.props.gptEnabled ? (
                         <div className="sidebar-ad">
@@ -410,6 +486,8 @@ module.exports = {
     path: ':order(/:category)',
     component: connect(
         (state, ownProps) => {
+            const scotConfig = state.app.get('scotConfig');
+
             return {
                 discussions: state.global.get('discussion_idx'),
                 status: state.global.get('status'),
@@ -430,6 +508,7 @@ module.exports = {
                     .get('notices')
                     .toJS(),
                 gptEnabled: state.app.getIn(['googleAds', 'gptEnabled']),
+                tokenStats: scotConfig.getIn(['config', 'tokenStats']),
             };
         },
         dispatch => {

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -247,7 +247,11 @@
             "warning":
                 "Legitimate users, including employees of Steemit Inc., will never ask you for a private key or master password.",
             "checkbox": "I understand"
-        }
+        },
+        "total": "Total",
+        "circulating": "Circulating",
+        "burn": "Burn",
+        "staking": "Staking"
     },
     "navigation": {
         "about": "About Steemit, Inc.",

--- a/src/app/locales/es.json
+++ b/src/app/locales/es.json
@@ -255,7 +255,11 @@
         },
         "post_as": "Publicar como",
         "vote_currently_exists_user_must_be_indicate_a_to_reject_witness":
-            "Este voto ya existe, el usuario tiene que quitar el voto al witness"
+            "Este voto ya existe, el usuario tiene que quitar el voto al witness",
+        "total": "Total",
+        "circulating": "Circulating",
+        "burn": "Burn",
+        "staking": "Staking"
     },
     "navigation": {
         "about": "Sobre",

--- a/src/app/locales/fr.json
+++ b/src/app/locales/fr.json
@@ -258,7 +258,11 @@
         },
         "post_as": "Poster en tant que",
         "vote_currently_exists_user_must_be_indicate_a_to_reject_witness":
-            "un vote existe actuellement; l'utilisateur doit indiquer une raison pour rejeter le témoin"
+            "un vote existe actuellement; l'utilisateur doit indiquer une raison pour rejeter le témoin",
+        "total": "Total",
+        "circulating": "Circulating",
+        "burn": "Burn",
+        "staking": "Staking"
     },
     "navigation": {
         "about": "A propos",

--- a/src/app/locales/it.json
+++ b/src/app/locales/it.json
@@ -256,7 +256,11 @@
         },
         "post_as": "Pubblica come",
         "vote_currently_exists_user_must_be_indicate_a_to_reject_witness":
-            "Attualmente il voto esiste, l'utente deve indicare la volonta di rigettare il witness "
+            "Attualmente il voto esiste, l'utente deve indicare la volonta di rigettare il witness ",
+        "total": "Total",
+        "circulating": "Circulating",
+        "burn": "Burn",
+        "staking": "Staking"
     },
     "navigation": {
         "about": "Circa",

--- a/src/app/locales/ja.json
+++ b/src/app/locales/ja.json
@@ -252,7 +252,11 @@
         },
         "post_as": "投稿します:",
         "vote_currently_exists_user_must_be_indicate_a_to_reject_witness":
-            "現在、投票が存在し、証人を拒否するには強い意志を示す必要があります"
+            "現在、投票が存在し、証人を拒否するには強い意志を示す必要があります",
+        "total": "Total",
+        "circulating": "Circulating",
+        "burn": "Burn",
+        "staking": "Staking"
     },
     "navigation": {
         "about": "Steemについて",

--- a/src/app/locales/ko.json
+++ b/src/app/locales/ko.json
@@ -248,7 +248,11 @@
         },
         "post_as": "Post as",
         "vote_currently_exists_user_must_be_indicate_a_to_reject_witness":
-            "vote currently exists, user must be indicate a desire to reject witness"
+            "vote currently exists, user must be indicate a desire to reject witness",
+        "total": "Total",
+        "circulating": "Circulating",
+        "burn": "Burn",
+        "staking": "Staking"
     },
     "navigation": {
         "about": "스팀이란?",

--- a/src/app/locales/pl.json
+++ b/src/app/locales/pl.json
@@ -251,7 +251,11 @@
         },
         "post_as": "Napisz jako",
         "vote_currently_exists_user_must_be_indicate_a_to_reject_witness":
-            "głos oddany, użytkownik musi wskazać powód odrzucenia delegata"
+            "głos oddany, użytkownik musi wskazać powód odrzucenia delegata",
+        "total": "Total",
+        "circulating": "Circulating",
+        "burn": "Burn",
+        "staking": "Staking"
     },
     "navigation": {
         "about": "O Steem",

--- a/src/app/locales/ru.json
+++ b/src/app/locales/ru.json
@@ -256,7 +256,11 @@
         },
         "post_as": "Запостить как",
         "vote_currently_exists_user_must_be_indicate_a_to_reject_witness":
-            "голос уже существует, пользователь должен обозначить желание убрать делегата"
+            "голос уже существует, пользователь должен обозначить желание убрать делегата",
+        "total": "Total",
+        "circulating": "Circulating",
+        "burn": "Burn",
+        "staking": "Staking"
     },
     "navigation": {
         "about": "О проекте",

--- a/src/app/locales/zh.json
+++ b/src/app/locales/zh.json
@@ -241,7 +241,11 @@
         },
         "post_as": "发布为",
         "vote_currently_exists_user_must_be_indicate_a_to_reject_witness":
-            "已经投过此见证人，你是否想取消此见证人的投票"
+            "已经投过此见证人，你是否想取消此见证人的投票",
+        "total": "Total",
+        "circulating": "Circulating",
+        "burn": "Burn",
+        "staking": "Staking"
     },
     "navigation": {
         "about": "关于",


### PR DESCRIPTION
### Feature

1. show the total, circulation, burn, staked info of tokens at the sidebar. 

### Test

- check out the test version here: https://steemleo.herokuapp.com

### Code Change

- `SidebarToken.jsx`: the token statistics widget
- `PostsIndex.jsx`: add the widget at siderbar
- `ScotConfig.js`: fetch token data with sscjs
- locales: add strings for the token stats titles

### Approval
@steemleo ( khaleelkazi ) has approved this change. feel free to DM him on Discord to confirm this PR.