### PR TITLE
Show beneficiary info

### DIFF
--- a/src/app/components/elements/Voting.jsx
+++ b/src/app/components/elements/Voting.jsx
@@ -496,6 +496,32 @@ class Voting extends React.Component {
             });
         }
 
+        // add beneficiary info. use toFixed due to a bug of formatDecimal (5.00 is shown as 5,.00)
+        const beneficiaries = post_obj.get('beneficiaries');
+        if (beneficiaries && !beneficiaries.isEmpty()) {
+            payoutItems.push({ value: tt('g.beneficiaries') });
+
+            beneficiaries.forEach(function(key) {
+                if (
+                    rewardData.exclude_beneficiaries_accounts.includes(
+                        key.get('account')
+                    )
+                ) {
+                    return;
+                }
+
+                payoutItems.push({
+                    value:
+                        '- ' +
+                        key.get('account') +
+                        ': ' +
+                        (parseFloat(key.get('weight')) / 100).toFixed(2) +
+                        '%',
+                    link: '/@' + key.get('account'),
+                });
+            });
+        }
+
         const payoutEl = (
             <DropdownMenu el="div" items={payoutItems}>
                 <span>

--- a/src/app/components/elements/Voting.jsx
+++ b/src/app/components/elements/Voting.jsx
@@ -498,9 +498,16 @@ class Voting extends React.Component {
 
         // add beneficiary info. use toFixed due to a bug of formatDecimal (5.00 is shown as 5,.00)
         const beneficiaries = post_obj.get('beneficiaries');
-        if (beneficiaries && !beneficiaries.isEmpty()) {
+        if (
+            rewardData.enable_comment_beneficiaries &&
+            beneficiaries &&
+            !beneficiaries.isEmpty()
+        ) {
             payoutItems.push({ value: tt('g.beneficiaries') });
 
+            // to remove tt('g.beneficiaries') in the above if there is no beneficiary,
+            // i.e., if all beneficiaries are in exclude_beneficiaries_accounts (e.g., @finex, @likwid)
+            let popBeneficiaries = true;
             beneficiaries.forEach(function(key) {
                 if (
                     rewardData.exclude_beneficiaries_accounts.includes(
@@ -510,6 +517,7 @@ class Voting extends React.Component {
                     return;
                 }
 
+                popBeneficiaries = false;
                 payoutItems.push({
                     value:
                         '- ' +
@@ -520,6 +528,9 @@ class Voting extends React.Component {
                     link: '/@' + key.get('account'),
                 });
             });
+            if (popBeneficiaries) {
+                payoutItems.pop(); // pop tt('g.beneficiaries')
+            }
         }
 
         const payoutEl = (
@@ -697,6 +708,14 @@ export default connect(
             author_curve_exponent: scotConfig.getIn([
                 'config',
                 'author_curve_exponent',
+            ]),
+            enable_comment_beneficiaries: scotConfig.getIn([
+                'config',
+                'enable_comment_beneficiaries',
+            ]),
+            exclude_beneficiaries_accounts: scotConfig.getIn([
+                'config',
+                'exclude_beneficiaries_accounts',
             ]),
         };
         // set author_curve_exponent to what's on the post (in case of transition period)


### PR DESCRIPTION
Show beneficiary info if exists
- only when `enable_comment_beneficiaries` is true 
- and beneficiary is not in `exclude_beneficiaries_accounts` e.g., finex, likwid

![](https://user-images.githubusercontent.com/38183982/61882957-6799e100-aef1-11e9-9ce9-185562878d4b.png)
> screenshot tested on local dev server for AAA. In my opinion, utopian.pay should also be added to `exclude_beneficiaries_accounts` globally :) But utopian will end soon anyway :(

![](https://user-images.githubusercontent.com/38183982/61882970-6ec0ef00-aef1-11e9-8068-3a71c820b04a.png)
> when beneficiary is in `exclude_beneficiaries_accounts`, it should not be shown. also, the header 'beneficiaries' itself should not be shown.

![](https://user-images.githubusercontent.com/38183982/61883246-fc044380-aef1-11e9-8043-25e53af4ba33.png)
> The same posting on Busy: https://busy.org/@blockchainstudio/scot-vp-viewer-vote-weight-multiplier-support
