### PR TITLE
fix tag order

### DIFF
--- a/src/app/client_config.js
+++ b/src/app/client_config.js
@@ -11,6 +11,8 @@ export const APP_ICON = 'weedcash';
 // vars. client should read $STM_Config, server should read config package.
 export const APP_URL = 'https://www.weedcash.network';
 export const APP_DOMAIN = 'www.weedcash.network';
+// max num of tags. if unset, default is 10. This is due to previous hardcoded number.
+export const APP_MAX_TAG = 12;
 export const SCOT_TAG = 'weedcash';
 export const TAG_LIST = fromJSOrdered([
     'weedcash',

--- a/src/app/client_config.js
+++ b/src/app/client_config.js
@@ -12,7 +12,7 @@ export const APP_ICON = 'weedcash';
 export const APP_URL = 'https://www.weedcash.network';
 export const APP_DOMAIN = 'www.weedcash.network';
 // max num of tags. if unset, default is 10. This is due to previous hardcoded number.
-export const APP_MAX_TAG = 12;
+export const APP_MAX_TAG = 10;
 export const SCOT_TAG = 'weedcash';
 export const TAG_LIST = fromJSOrdered([
     'weedcash',

--- a/src/app/components/cards/CategorySelector.jsx
+++ b/src/app/components/cards/CategorySelector.jsx
@@ -4,6 +4,9 @@ import { connect } from 'react-redux';
 import shouldComponentUpdate from 'app/utils/shouldComponentUpdate';
 import { cleanReduxInput } from 'app/utils/ReduxForms';
 import tt from 'counterpart';
+import { APP_MAX_TAG } from 'app/client_config';
+
+const MAX_TAG = APP_MAX_TAG || 10;
 
 class CategorySelector extends React.Component {
     static propTypes = {
@@ -101,9 +104,9 @@ export function validateCategory(category, required = true) {
     const cats = category.trim().split(' ');
     return (
         // !category || category.trim() === '' ? 'Required' :
-        cats.length > 10
+        cats.length > MAX_TAG
             ? tt('category_selector_jsx.use_limited_amount_of_categories', {
-                  amount: 10,
+                  amount: MAX_TAG,
               })
             : cats.find(c => c.length > 24)
               ? tt('category_selector_jsx.maximum_tag_length_is_24_characters')

--- a/src/app/components/elements/ReplyEditor.jsx
+++ b/src/app/components/elements/ReplyEditor.jsx
@@ -13,7 +13,7 @@ import sanitizeConfig, { allowedTags } from 'app/utils/SanitizeConfig';
 import sanitize from 'sanitize-html';
 import HtmlReady from 'shared/HtmlReady';
 import * as globalActions from 'app/redux/GlobalReducer';
-import { fromJS, Set } from 'immutable';
+import { fromJS, OrderedSet } from 'immutable';
 import Remarkable from 'remarkable';
 import Dropzone from 'react-dropzone';
 import tt from 'counterpart';
@@ -807,7 +807,9 @@ export default formId =>
             let { category, title, body } = ownProps;
             if (/submit_/.test(type)) title = body = '';
             if (isStory && jsonMetadata && jsonMetadata.tags) {
-                category = Set([category, ...jsonMetadata.tags]).join(' ');
+                category = OrderedSet([category, ...jsonMetadata.tags]).join(
+                    ' '
+                );
             }
 
             const defaultPayoutType = state.app.getIn(
@@ -952,7 +954,7 @@ export default formId =>
                     return;
                 }
 
-                const formCategories = Set(
+                const formCategories = OrderedSet(
                     category
                         ? category
                               .trim()
@@ -964,11 +966,12 @@ export default formId =>
                     originalPost && originalPost.category
                         ? originalPost.category
                         : formCategories.first();
-                let allCategories = Set([...formCategories.toJS()]);
+                let allCategories = OrderedSet([...formCategories.toJS()]);
                 if (/^[-a-z\d]+$/.test(rootCategory))
                     allCategories = allCategories.add(rootCategory);
 
                 let postHashtags = [...rtags.hashtags];
+                // "- allCategories.includes(SCOT_TAG) ? 0 : 1" to save the last tag space for SCOT_TAG
                 while (
                     allCategories.size <
                     MAX_TAG - allCategories.includes(SCOT_TAG)

--- a/src/app/components/elements/ReplyEditor.jsx
+++ b/src/app/components/elements/ReplyEditor.jsx
@@ -17,11 +17,12 @@ import { fromJS, Set } from 'immutable';
 import Remarkable from 'remarkable';
 import Dropzone from 'react-dropzone';
 import tt from 'counterpart';
-import { APP_NAME, SCOT_TAG } from 'app/client_config';
+import { APP_NAME, SCOT_TAG, APP_MAX_TAG } from 'app/client_config';
 
 const remarkable = new Remarkable({ html: true, linkify: false, breaks: true });
 
 const RTE_DEFAULT = false;
+const MAX_TAG = APP_MAX_TAG || 10;
 
 class ReplyEditor extends React.Component {
     static propTypes = {
@@ -968,7 +969,12 @@ export default formId =>
                     allCategories = allCategories.add(rootCategory);
 
                 let postHashtags = [...rtags.hashtags];
-                while (allCategories.size < 5 && postHashtags.length > 0) {
+                while (
+                    allCategories.size <
+                    MAX_TAG - allCategories.includes(SCOT_TAG)
+                        ? 0
+                        : 1 && postHashtags.length > 0
+                ) {
                     allCategories = allCategories.add(postHashtags.shift());
                 }
                 // Add scot tag
@@ -998,7 +1004,7 @@ export default formId =>
                     return;
                 }
 
-                if (meta.tags.length > 10) {
+                if (meta.tags.length > MAX_TAG) {
                     const includingCategory = isEdit
                         ? tt('reply_editor.including_the_category', {
                               rootCategory,


### PR DESCRIPTION
Fix #56 

1. introduce `MAX_TAG` and `APP_MAX_TAG` to avoid hardcoded max num of tags

2. fix tag order
should use `OrderedSet` instead of `Set`

This was difficult to find, since standard JS library Set preserves the order,

and immutable library Set also preserve the order up to 8 elements! Why up to 8!

Anyway, now the problem has been resolved. Enjoy the untangled tag order in the dead PoB society :)


<img width="547" src="https://user-images.githubusercontent.com/38183982/61998250-234f4200-b0a5-11e9-84f4-1a3a4037a50f.png">

> previously tag order is tangled. https://busy.org/@guest123/j1tbe-test


![](https://user-images.githubusercontent.com/38183982/61998281-91940480-b0a5-11e9-948b-f7beb974d2c6.png)

> fixed. You can also see duplicated tag is automatically removed, and `APP_NAME` is added to the last position if it's not added by users. https://busy.org/@guest123/tag-order-test