### PR TITLE
The writing page was modified. The preview is on the right.

### DIFF
--- a/src/app/components/elements/ReplyEditor.jsx
+++ b/src/app/components/elements/ReplyEditor.jsx
@@ -711,37 +711,37 @@ class ReplyEditor extends React.Component {
                                     </div>
                                 )}
                         </div>
-                        {!loading &&
-                            !rte &&
-                            body.value && (
-                                <div
-                                    className={
-                                        'Preview ' + vframe_section_shrink_class
-                                    }
-                                >
-                                    {!isHtml && (
-                                        <div className="float-right">
-                                            <a
-                                                target="_blank"
-                                                href="https://guides.github.com/features/mastering-markdown/"
-                                                rel="noopener noreferrer"
-                                            >
-                                                {tt(
-                                                    'reply_editor.markdown_styling_guide'
-                                                )}
-                                            </a>
-                                        </div>
-                                    )}
-                                    <h6>{tt('g.preview')}</h6>
-                                    <MarkdownViewer
-                                        text={body.value}
-                                        jsonMetadata={jsonMetadata}
-                                        large={isStory}
-                                        noImage={noImage}
-                                    />
-                                </div>
-                            )}
                     </form>
+                    {!loading &&
+                        !rte &&
+                        body.value && (
+                            <div
+                                className={
+                                    'Preview ' + vframe_section_shrink_class
+                                }
+                            >
+                                {!isHtml && (
+                                    <div className="float-right">
+                                        <a
+                                            target="_blank"
+                                            href="https://guides.github.com/features/mastering-markdown/"
+                                            rel="noopener noreferrer"
+                                        >
+                                            {tt(
+                                                'reply_editor.markdown_styling_guide'
+                                            )}
+                                        </a>
+                                    </div>
+                                )}
+                                <h6>{tt('g.preview')}</h6>
+                                <MarkdownViewer
+                                    text={body.value}
+                                    jsonMetadata={jsonMetadata}
+                                    large={isStory}
+                                    noImage={noImage}
+                                />
+                            </div>
+                        )}
                 </div>
             </div>
         );

--- a/src/app/components/elements/ReplyEditor.scss
+++ b/src/app/components/elements/ReplyEditor.scss
@@ -124,3 +124,28 @@
 .Dropdown__root___1B9ta {
   color: black!important;
 }
+
+/* Medium only */
+@media screen and (min-width: 768px) {
+  .ReplyEditor {
+    max-width: 108rem;
+    .column {
+      display: flex;
+    }
+    .vframe {
+      margin-left: auto;
+      margin-right: auto;
+    }
+    .upload-enabled {
+      min-height: calc(100vh - 500px);
+    }
+    .Preview {
+      width: 100%;
+      margin-left: 1em;
+      .MarkdownViewer {
+        max-height: calc(100vh - 150px);
+        overflow-y: scroll;
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Enhancements
When you write in `Markdown` and `HTML`, the preview is shown on the right.
However, this does not apply to mobile.

### Preview
You can preview the feature in our test site: https://anpigon.herokuapp.com/submit.html

![screenshot](https://user-images.githubusercontent.com/3969643/62001320-bed5c680-b128-11e9-8e4d-9b665a4cf103.png)

