### PR TITLE
Load more posts fix for Certified feed

### DIFF
--- a/src/app/redux/FetchDataSaga.js
+++ b/src/app/redux/FetchDataSaga.js
@@ -289,6 +289,13 @@ export function* fetchData(action) {
                 start_permlink: permlink,
             },
         ];
+    } else if (order === 'certified') {
+        call_name = 'getDiscussionsByCertifiedAsync';
+        args = [
+            {
+                limit: constants.FETCH_DATA_BATCH_SIZE,
+            },
+        ];
     } else {
         // this should never happen. undefined behavior
         call_name = 'getDiscussionsByTrendingAsync';

--- a/src/app/utils/steemApi.js
+++ b/src/app/utils/steemApi.js
@@ -8,6 +8,7 @@ import axios from 'axios';
 import SSC from 'sscjs';
 
 const ssc = new SSC('https://api.steem-engine.com/rpc');
+let asyncCounter = 0;
 
 async function callApi(url, params) {
     return await axios({
@@ -296,6 +297,7 @@ export async function getStateAsync(url) {
 }
 
 export async function fetchFeedDataAsync(call_name, ...args) {
+    asyncCounter = asyncCounter + 1;
     const fetchSize = args[0].limit;
     let feedData;
     // To indicate if there are no further pages in feed.
@@ -317,6 +319,7 @@ export async function fetchFeedDataAsync(call_name, ...args) {
         if (order == 'certified') {
             path = `get_feed`;
             discussionQuery.account = CERTIFIED_POST_ACCOUNT;
+            discussionQuery.start_entry_id = asyncCounter * fetchSize;
         }
         if (!discussionQuery.tag) {
             // If empty string, remove from query.

--- a/src/app/utils/steemApi.js
+++ b/src/app/utils/steemApi.js
@@ -297,7 +297,6 @@ export async function getStateAsync(url) {
 }
 
 export async function fetchFeedDataAsync(call_name, ...args) {
-    asyncCounter = asyncCounter + 1;
     const fetchSize = args[0].limit;
     let feedData;
     // To indicate if there are no further pages in feed.
@@ -317,10 +316,12 @@ export async function fetchFeedDataAsync(call_name, ...args) {
         let path = `get_discussions_by_${order}`;
 
         if (order == 'certified') {
+            asyncCounter = asyncCounter + 1;
             path = `get_feed`;
             discussionQuery.account = CERTIFIED_POST_ACCOUNT;
             discussionQuery.start_entry_id = asyncCounter * fetchSize;
         }
+
         if (!discussionQuery.tag) {
             // If empty string, remove from query.
             delete discussionQuery.tag;


### PR DESCRIPTION
- getDiscussionsByCertifiedAsync added to FetchDataSaga.js to load more posts from the certified feed
- start_entry_id parameter added to discussionQuery in steemApi.js in order to get next x items starting from start_entry_id.
- asyncCounter variable introduced within steemApi.js in order to keep track of start_entry_id to get next x posts