### PR TITLE
Menu link action fix on Grow & Favorite mentor pages

### DIFF
--- a/blackboxtest/nightwatch-tests/ssr.js
+++ b/blackboxtest/nightwatch-tests/ssr.js
@@ -19,6 +19,8 @@ module.exports = {
             '/change_password',
             '/recover_account_step_1',
             '/market',
+            '/favorite-mentor',
+            '/grow',
             '/submit.html',
         ].forEach(path => testHttpGet('localhost', 8080, path, browser));
     },

--- a/src/app/ResolveRoute.test.js
+++ b/src/app/ResolveRoute.test.js
@@ -35,6 +35,8 @@ describe('resolveRoute', () => {
     const test_cases = [
         ['/', { page: 'PostsIndex', params: ['trending'] }],
         ['/about.html', { page: 'About' }],
+        ['/grow', { page: 'Grow' }],
+        ['/favorite-mentor', { page: 'FavoriteMentor' }],
         ['/faq.html', { page: 'Faq' }],
         ['/login.html', { page: 'Login' }],
         ['/privacy.html', { page: 'Privacy' }],

--- a/src/app/components/pages/Grow.js
+++ b/src/app/components/pages/Grow.js
@@ -70,13 +70,11 @@ class Grow extends React.Component {
                                                         Our TV(s)
                                                     </h3>
                                                     <div className="antContent">
-                                                        <p>
-                                                            <ReactMarkdown
-                                                                source={
-                                                                    growSections.submitAVideo
-                                                                }
-                                                            />
-                                                        </p>
+                                                        <ReactMarkdown
+                                                            source={
+                                                                growSections.submitAVideo
+                                                            }
+                                                        />
                                                     </div>
                                                     <a
                                                         className="ant-btn ant-btn-primary"
@@ -89,7 +87,7 @@ class Grow extends React.Component {
                                             <div className="ant-list-item-extra">
                                                 <div
                                                     role="presentation"
-                                                    class="VideoEmbed"
+                                                    className="VideoEmbed"
                                                 >
                                                     <GrowVideoEmbed
                                                         key="embed"
@@ -113,13 +111,11 @@ class Grow extends React.Component {
                                                 <div className="ant-list-item-content ant-list-item-content-single">
                                                     <h3>Write To Ulogs.org</h3>
                                                     <div className="antContent">
-                                                        <p>
-                                                            <ReactMarkdown
-                                                                source={
-                                                                    growSections.writeToUlogs
-                                                                }
-                                                            />
-                                                        </p>
+                                                        <ReactMarkdown
+                                                            source={
+                                                                growSections.writeToUlogs
+                                                            }
+                                                        />
                                                     </div>
                                                     <a
                                                         className="ant-btn ant-btn-primary"
@@ -132,7 +128,7 @@ class Grow extends React.Component {
                                             <div className="ant-list-item-extra">
                                                 <div
                                                     role="presentation"
-                                                    class="VideoEmbed"
+                                                    className="VideoEmbed"
                                                 >
                                                     <GrowVideoEmbed
                                                         key="embed"
@@ -159,13 +155,11 @@ class Grow extends React.Component {
                                                         Your Favorite Mentor
                                                     </h3>
                                                     <div className="antContent">
-                                                        <p>
-                                                            <ReactMarkdown
-                                                                source={
-                                                                    growSections.fifteenMinuteMentor
-                                                                }
-                                                            />
-                                                        </p>
+                                                        <ReactMarkdown
+                                                            source={
+                                                                growSections.fifteenMinuteMentor
+                                                            }
+                                                        />
                                                     </div>
                                                     <a
                                                         className="ant-btn ant-btn-primary"
@@ -178,7 +172,7 @@ class Grow extends React.Component {
                                             <div className="ant-list-item-extra">
                                                 <div
                                                     role="presentation"
-                                                    class="VideoEmbed"
+                                                    className="VideoEmbed"
                                                 >
                                                     <GrowVideoEmbed
                                                         key="embed"
@@ -207,13 +201,11 @@ class Grow extends React.Component {
                                                         Steem Community
                                                     </h3>
                                                     <div className="antContent">
-                                                        <p>
-                                                            <ReactMarkdown
-                                                                source={
-                                                                    growSections.thirtyMinuteSymposium
-                                                                }
-                                                            />
-                                                        </p>
+                                                        <ReactMarkdown
+                                                            source={
+                                                                growSections.thirtyMinuteSymposium
+                                                            }
+                                                        />
                                                     </div>
                                                     <a
                                                         className="ant-btn ant-btn-primary"
@@ -226,7 +218,7 @@ class Grow extends React.Component {
                                             <div className="ant-list-item-extra">
                                                 <div
                                                     role="presentation"
-                                                    class="VideoEmbed"
+                                                    className="VideoEmbed"
                                                 >
                                                     <GrowVideoEmbed
                                                         key="embed"
@@ -253,13 +245,11 @@ class Grow extends React.Component {
                                                         Steem Or Outside Steem
                                                     </h3>
                                                     <div className="antContent">
-                                                        <p>
-                                                            <ReactMarkdown
-                                                                source={
-                                                                    growSections.extraClout
-                                                                }
-                                                            />
-                                                        </p>
+                                                        <ReactMarkdown
+                                                            source={
+                                                                growSections.extraClout
+                                                            }
+                                                        />
                                                     </div>
                                                     <a
                                                         className="ant-btn ant-btn-primary"
@@ -272,7 +262,7 @@ class Grow extends React.Component {
                                             <div className="ant-list-item-extra">
                                                 <div
                                                     role="presentation"
-                                                    class="VideoEmbed"
+                                                    className="VideoEmbed"
                                                 >
                                                     <GrowVideoEmbed
                                                         key="embed"
@@ -300,13 +290,11 @@ class Grow extends React.Component {
                                                         Life-Changing Move?
                                                     </h3>
                                                     <div className="antContent">
-                                                        <p>
-                                                            <ReactMarkdown
-                                                                source={
-                                                                    growSections.extraConfidence
-                                                                }
-                                                            />
-                                                        </p>
+                                                        <ReactMarkdown
+                                                            source={
+                                                                growSections.extraConfidence
+                                                            }
+                                                        />
                                                     </div>
                                                     <a
                                                         className="ant-btn ant-btn-primary"
@@ -319,7 +307,7 @@ class Grow extends React.Component {
                                             <div className="ant-list-item-extra">
                                                 <div
                                                     role="presentation"
-                                                    class="VideoEmbed"
+                                                    className="VideoEmbed"
                                                 >
                                                     <GrowVideoEmbed
                                                         key="embed"
@@ -347,13 +335,11 @@ class Grow extends React.Component {
                                                         e.g Depression?
                                                     </h3>
                                                     <div className="antContent">
-                                                        <p>
-                                                            <ReactMarkdown
-                                                                source={
-                                                                    growSections.hardToExplainAilment
-                                                                }
-                                                            />
-                                                        </p>
+                                                        <ReactMarkdown
+                                                            source={
+                                                                growSections.hardToExplainAilment
+                                                            }
+                                                        />
                                                     </div>
                                                     <a
                                                         className="ant-btn ant-btn-primary"
@@ -366,7 +352,7 @@ class Grow extends React.Component {
                                             <div className="ant-list-item-extra">
                                                 <div
                                                     role="presentation"
-                                                    class="VideoEmbed"
+                                                    className="VideoEmbed"
                                                 >
                                                     <GrowVideoEmbed
                                                         key="embed"
@@ -393,13 +379,11 @@ class Grow extends React.Component {
                                                         Or Mail
                                                     </h3>
                                                     <div className="antContent">
-                                                        <p>
-                                                            <ReactMarkdown
-                                                                source={
-                                                                    growSections.sendUsSomething
-                                                                }
-                                                            />
-                                                        </p>
+                                                        <ReactMarkdown
+                                                            source={
+                                                                growSections.sendUsSomething
+                                                            }
+                                                        />
                                                     </div>
                                                     <a
                                                         className="ant-btn ant-btn-primary"
@@ -412,7 +396,7 @@ class Grow extends React.Component {
                                             <div className="ant-list-item-extra">
                                                 <div
                                                     role="presentation"
-                                                    class="VideoEmbed"
+                                                    className="VideoEmbed"
                                                 >
                                                     <GrowVideoEmbed
                                                         key="embed"
@@ -436,13 +420,11 @@ class Grow extends React.Component {
                                                 <div className="ant-list-item-content ant-list-item-content-single">
                                                     <h3>Inspire Us</h3>
                                                     <div className="antContent">
-                                                        <p>
-                                                            <ReactMarkdown
-                                                                source={
-                                                                    growSections.inspireUs
-                                                                }
-                                                            />
-                                                        </p>
+                                                        <ReactMarkdown
+                                                            source={
+                                                                growSections.inspireUs
+                                                            }
+                                                        />
                                                     </div>
                                                     <a
                                                         className="ant-btn ant-btn-primary"
@@ -455,7 +437,7 @@ class Grow extends React.Component {
                                             <div className="ant-list-item-extra">
                                                 <div
                                                     role="presentation"
-                                                    class="VideoEmbed"
+                                                    className="VideoEmbed"
                                                 >
                                                     <GrowVideoEmbed
                                                         key="embed"

--- a/src/app/components/pages/PostsIndex.jsx
+++ b/src/app/components/pages/PostsIndex.jsx
@@ -67,7 +67,10 @@ class PostsIndex extends React.Component {
               : []
             : [];
         const notices = this.props.notices || [];
-        const topic_discussions = this.props.discussions.get(category || '');
+        const topic_discussions =
+            this.props.discussions != null
+                ? this.props.discussions.get(category || '')
+                : null;
         if (!topic_discussions) return { posts: List(), promotedPosts: List() };
         const mainDiscussions = topic_discussions.get(order);
         if (INTERLEAVE_PROMOTED && (order === 'trending' || order === 'hot')) {
@@ -259,7 +262,8 @@ class PostsIndex extends React.Component {
         const fetching = (status && status.fetching) || this.props.loading;
         const { showSpam } = this.state;
 
-        const topicDiscussions = discussions.get(category || '');
+        const topicDiscussions =
+            discussions != null ? discussions.get(category || '') : null;
 
         // If we're at one of the four sort order routes without a tag filter,
         // use the translated string for that sort order, f.ex "trending"


### PR DESCRIPTION
- Null checks added to PostsIndex.jsx in case of missing discussions property
- PR https://github.com/steem-engine-exchange/nitrous/issues/93