### PR TITLE
Visual separation in wallet

### DIFF
--- a/src/app/components/modules/UserWallet.jsx
+++ b/src/app/components/modules/UserWallet.jsx
@@ -450,6 +450,7 @@ class UserWallet extends React.Component {
                         </div>
                     </div>
                 )}
+                <hr />
                 {/* STEEM */}
                 <div className="UserWallet__balance row">
                     <div className="column small-12 medium-8">
@@ -540,6 +541,7 @@ class UserWallet extends React.Component {
                         )}
                     </div>
                 </div>
+                <hr />
                 {/* Steem Engine Tokens */}
                 {otherTokenBalances && otherTokenBalances.length ? (
                     <div


### PR DESCRIPTION
Issue #131 
This PR if for Visual separation between Tribe Token and Steem Wallet by adding Horizontal Line.

![image](https://user-images.githubusercontent.com/13746289/66291817-5e20f200-e900-11e9-9347-502a6cdbc55e.png)

